### PR TITLE
Add pub-js-only-i18n tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ nodeConfig.addTech([require('enb-priv-js/techs/pub-js-i18n'), {
 }]
 ```
 
+## pub-js-only-i18n
+
+Собирает *{lang}.pub.js*-файл из *js* и языковых файлов.
+
+**Опции**
+
+* *String* **target** — Результирующий `pub.js`-файл. По умолчанию — `?.all.pub.js`.
+* *String* **jsTarget** — Исходный `js`-файл. По умолчанию — `?.js`.
+* *String* **lang** — Язык. Обязательная опция.
+* *String* **langTarget** — `lang.js`-файл конкретного языка. Например, `?.lang.ru.js`.
+  По умолчанию — `?.lang.{lang}.js`.
+* *String* **allLangTarget** — `lang.all.js`-файл. По умолчанию — `?.lang.all.js`.
+
+**Пример**
+
+```js
+nodeConfig.addTech([require('enb-priv-js/techs/pub-js-only-i18n'), {
+  target: '?.{lang}.js',
+  lang: '{lang}'
+}]
+```
+
 ## priv-server
 
 Склеивает *priv*-файлы по deps'ам с помощью набора `require` в виде `?.priv.js`.

--- a/techs/pub-js-only-i18n.js
+++ b/techs/pub-js-only-i18n.js
@@ -1,0 +1,33 @@
+/**
+ * pub-js-only-i18n
+ * ===========
+ *
+ * Собирает *{lang}.pub.js*-файл из *js* и языковых файлов.
+ *
+ * **Опции**
+ *
+ * * *String* **target** — Результирующий `pub.js`-файл. По умолчанию — `?.all.pub.js`.
+ * * *String* **jsTarget** — Исходный `js`-файл. По умолчанию — `?.js`.
+ * * *String* **lang** — Язык. Обязательная опция.
+ * * *String* **langTarget** — `lang.js`-файл конкретного языка. Например, `?.lang.ru.js`.
+ *   По умолчанию — `?.lang.{lang}.js`.
+ * * *String* **allLangTarget** — `lang.all.js`-файл. По умолчанию — `?.lang.all.js`.
+ *
+ * **Пример**
+ *
+ * ```js
+ * nodeConfig.addTech([require('enb-priv-js/techs/pub-js-only-i18n'), {
+ *   target: '?.{lang}.js',
+ *   lang: '{lang}'
+ * }]
+ * ```
+ */
+module.exports = require('enb/lib/build-flow').create()
+    .name('pub-js-only-i18n')
+    .target('target', '?.{lang}.pub.js')
+    .defineRequiredOption('lang')
+    .useSourceFilename('jsTarget', '?.js')
+    .useSourceFilename('allLangTarget', '?.lang.all.js')
+    .useSourceFilename('langTarget', '?.lang.{lang}.js')
+    .justJoinFilesWithComments()
+    .createTech();


### PR DESCRIPTION
Добавляется технология для сборки клиентского js c i18n, но без добавления bemhtml-шаблонов.
Добавляю новую технологию, т.к. для модификации существующей pub-js-i18n ничего лучше следующего подхода сделать не удалось:
```js
    // ...
    .defineOption('needToAddBemhtml', true)
    .prepare(function() {
        var usages = this.constructor.buildFlow()._usages;
        if (!this._needToAddBemhtml && usages[0]._targetOptionName === 'bemhtmlTarget') {
            usages.shift();
        }

        this._requireSources = function () {
            var _this = this;
            var node = this.node;
            return Vow.all(usages.map(function (usage) {
                return usage.requireTarget(_this, node);
            }));
        };
    })
    .justJoinFilesWithComments()
    .createTech();
```